### PR TITLE
Add unstyled/nonfunctional settings page

### DIFF
--- a/src/settings.html
+++ b/src/settings.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>TokyoDrift: Settings</title>
+
+  </head>
+  <body>
+    <h1 style="text-align: center;">Settings</h1>
+    <hr />
+    <table>
+        <tr>
+            <td>Work period ("Pomodoro") length</td>
+            <td><input type="number" value="25" min="1" max="1440" /> minutes</td>
+        </tr>
+        <tr>
+            <td>Short break length</td>
+            <td><input type="number" value="5" min="1" max="1440" /> minutes</td>
+        </tr>
+        <tr>
+            <td>Long break length</td>
+            <td><input type="number" value="20" min="1" max="1440" /> minutes</td>
+        </tr>
+        <tr>
+            <td>Number of work periods per session</td>
+            <td><input type="number" value="4" min="2" max="20" /> work periods</td>
+        </tr>
+    </table>
+    <p style="text-align: center;">Please note that these changes will only take effect upon starting a new session.</p>
+  </body>
+</html>

--- a/src/settings.html
+++ b/src/settings.html
@@ -11,19 +11,19 @@
     <table>
         <tr>
             <td>Work period ("Pomodoro") length</td>
-            <td><input type="number" value="25" min="1" max="1440" /> minutes</td>
+            <td><input type="number" id="work-period-duration" value="25" min="1" max="1440" /> minutes</td>
         </tr>
         <tr>
             <td>Short break length</td>
-            <td><input type="number" value="5" min="1" max="1440" /> minutes</td>
+            <td><input type="number" id="short-break-duration" value="5" min="1" max="1440" /> minutes</td>
         </tr>
         <tr>
             <td>Long break length</td>
-            <td><input type="number" value="20" min="1" max="1440" /> minutes</td>
+            <td><input type="number" id="long-break-duration" value="20" min="1" max="1440" /> minutes</td>
         </tr>
         <tr>
             <td>Number of work periods per session</td>
-            <td><input type="number" value="4" min="2" max="20" /> work periods</td>
+            <td><input type="number" id="num-work-periods" value="4" min="2" max="20" /> work periods</td>
         </tr>
     </table>
     <p style="text-align: center;">Please note that these changes will only take effect upon starting a new session.</p>


### PR DESCRIPTION
# Description

Just adds the HTML for a settings page. This is not used for anything, yet, but once we have the first implementation ready we should be able to connect this page to the rest of the application.

![image](https://user-images.githubusercontent.com/4177727/99919157-90420e80-2cd0-11eb-8c80-a8b9aa42f8ed.png)

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- tested manually that it looks good by (temporarily) replacing `index.html` with `settings.html` in `package.json`. Eventually of course we will need to add a button / menu to the main HTML that, when clicked, opens up this HTML.