### PR TITLE
add desktop notification

### DIFF
--- a/src/js/script.js
+++ b/src/js/script.js
@@ -1,3 +1,5 @@
+const { remote } = require("electron");
+const { Notification }=remote;
 
 //*** utility functions ***
 function back2manu(){
@@ -63,6 +65,22 @@ var curr_workperiod = 0;
 var total_secs = total_work;
 //total_secs is whatever displays on the clock
 
+// desktop notification
+function showNotification (notif_kind) {
+  if(notif_kind==0){
+    new Notification({title: 'Pomodoro Sessions',
+      body: 'Congratulations! All sessions complete.'}).show();
+  }
+  else if(notif_kind==1){
+    new Notification({title: 'Pomodoro Session',
+      body: 'One working session completes.'}).show();
+  }
+  else if(notif_kind==2){
+    new Notification({title: 'Pomodoro Session',
+      body: 'One working session starts.'}).show();
+  }
+  // more notification kinds could be added here
+}
 
 // clock
 function showtime() {
@@ -80,6 +98,7 @@ function showtime() {
       total_secs = total_long_break;
     }
     //switch to break mode
+    showNotification(1); // show desktop notification for one session ends
     curr_session = 2;
     document.body.style.backgroundColor = "#D0E9F3";
     document.getElementById("tomato_img").src = "../images/tomatoblue_tran.png";
@@ -95,6 +114,7 @@ function showtime() {
   if (curr_session == 2 && total_secs < 0) {
     // if breaking and no remaining secs
     if (curr_workperiod == total_periods){
+      showNotification(0); // show desktop notification for all sessions end
       var r = confirm("Session complete! Go back to manu? ");
       if (r == true){
         location.href = "../home.html";
@@ -104,6 +124,7 @@ function showtime() {
     }else{
       curr_workperiod = curr_workperiod+1;
       //switch to work 
+      showNotification(2); // show desktop notification for one session starts
       curr_session = 1;
       total_secs = total_work;
       document.body.style.backgroundColor = "#F1DCDC";

--- a/src/main.js
+++ b/src/main.js
@@ -1,4 +1,4 @@
-const { app, BrowserWindow } = require("electron");
+const { app, BrowserWindow, Notification } = require("electron");
 
 // Handle creating/removing shortcuts on Windows when installing/uninstalling.
 if (require("electron-squirrel-startup")) {
@@ -16,6 +16,7 @@ const createWindow = () => {
     height: 600,
     webPreferences: {
       nodeIntegration: true,
+      enableRemoteModule: true
     },
   });
 
@@ -30,7 +31,7 @@ const createWindow = () => {
   // mainWindow.loadURL(MAIN_WINDOW_WEBPACK_ENTRY);
   console.log("here");
   // Open the DevTools.
-  // mainWindow.webContents.openDevTools();
+  mainWindow.webContents.openDevTools();
   mainWindow.webContents.on("did-finish-load", () => {
     mainWindow.webContents.send("timer-change", 0);
   });


### PR DESCRIPTION
# Description

Add the desktop notification of session start, complete and all sessions completes.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Test manually to see if it works.