### PR TITLE
Add back 'npm run package' step to CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,8 +19,7 @@ script:
   - npm run lint
   - npm run stylecheck
   - npm run test:unit
-  # TODO: re-enable
-  # - npm run package
+  - npm run package
   - npm run doc
 
 cache:


### PR DESCRIPTION
# Description

Adds back `npm run package` to the CI. This ensures the diagram used in the report and slides is accurate.

# How Has This Been Tested?

Manual testing that `npm run package` works